### PR TITLE
🔒 Dockerイメージ脆弱性スキャンにTrivyを導入 (#38)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,22 @@ jobs:
       - name: Build images
         run: docker compose build
 
+      - name: Scan backend image with Trivy
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ai-math-backend:ci
+          format: table
+          exit-code: 1
+          severity: CRITICAL,HIGH
+
+      - name: Scan frontend image with Trivy
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ai-math-frontend:ci
+          format: table
+          exit-code: 1
+          severity: CRITICAL,HIGH
+
       - name: Start services
         run: docker compose up -d
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       retries: 5
 
   backend:
+    image: ai-math-backend:ci
     build:
       context: .
       dockerfile: backend/Dockerfile
@@ -35,6 +36,7 @@ services:
         condition: service_healthy
 
   frontend:
+    image: ai-math-frontend:ci
     build:
       context: ./frontend
     container_name: ai-math-frontend


### PR DESCRIPTION
## 概要

Dockerイメージのビルド時にTrivyで脆弱性スキャンを実行し、既知のCVEを含むイメージがデプロイされないようにする。

## 変更内容

1. **docker-compose.yml**: backend/frontend サービスに `image:` タグを追加（Trivyスキャン用に明示的なイメージ名）
2. **ci.yml**: dockerジョブにTrivyスキャンステップを追加（critical/high で Fail）

## スキャンフロー

`docker compose build` → Trivyスキャン（backend + frontend） → 問題なければ起動・ヘルスチェック

## 検証

- CIのdockerジョブでbuild後に自動スキャン実行
- TRIVY_CRITICAL/HIGH が見つかった場合は exit code 1 で Fail
- 結果はジョブログの table 形式で確認可能