### PR TITLE
🐳 開発用Docker Composeを追加（ホットリロード対応） (#39)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,8 @@ Env file: `frontend/.env.local`.
 
 ### Docker Compose
 ```bash
-docker compose up -d            # postgres + backend(:8001) + frontend(:3000)
+docker compose up -d            # production: postgres + backend(:8001) + frontend(:3000)
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d  # dev with hot-reload
 docker compose down -v
 ```
 Root `.env` supplies `POSTGRES_PASSWORD`, `OPENROUTER_API_KEY`, `NEXTAUTH_SECRET`.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,25 @@
+services:
+  backend:
+    command: uvicorn backend.main:app --reload --host 0.0.0.0 --port 8000
+    volumes:
+      - ./backend:/app/backend
+      - ./backend/alembic.ini:/app/alembic.ini
+      - ./backend/alembic:/app/alembic
+    ports:
+      - "8000:8000"
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+      - /app/.next
+    ports:
+      - "3000:3000"
+    environment:
+      NODE_ENV: development
+      CHOKIDAR_USEPOLLING: "true"
+      WATCHPACK_POLLING: "true"
+      NEXT_TELEMETRY_DISABLED: "1"

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,14 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+RUN npm install -g pnpm@10.12.1
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+
+ENV NEXT_TELEMETRY_DISABLED=1
+
+CMD ["pnpm", "dev"]


### PR DESCRIPTION
## 概要

本番用ビルド前提のDocker Composeに加え、開発時用のホットリロード対応Composeファイルを追加。

## 変更内容

- **docker-compose.dev.yml**: `docker-compose.yml` を上書きする開発用Compose
  - backend: `--reload` 付きuvicorn起動 + ソースコードvolumeマウント
  - frontend: 専用Dockerfile.dev + volumeマウント（node_modules/.nextはanonymous volumeで保持）
  - backend port 8000 を直接公開
- **frontend/Dockerfile.dev**: 開発用の軽量Dockerfile（pnpm dev起動）

## 使い方

```
docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
```

コード変更が即座にコンテナに反映される。

## 検証観点

- コード変更でbackendが自動リロード（uvicorn --reload）
- frontendの変更が即座にブラウザに反映（Next.js HMR）
- node_modules がvolumeマウントで上書きされない