### PR TITLE
🚀 Vercel+RailwayへのCDパイプライン構築 (#41)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+
+jobs:
+  deploy-frontend:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel
+
+      - name: Deploy to Vercel
+        run: |
+          vercel deploy \
+            --prod \
+            --token=${{ secrets.VERCEL_TOKEN }} \
+            --scope=${{ secrets.VERCEL_ORG_ID }} \
+            --confirm
+        working-directory: frontend
+
+  deploy-backend:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Railway CLI
+        uses: railwayapp/railway-actions/install@v3
+
+      - name: Deploy to Railway
+        run: railway up --service=${{ secrets.RAILWAY_SERVICE_ID }} --ci
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        working-directory: backend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,15 @@ Root `.env` supplies `POSTGRES_PASSWORD`, `OPENROUTER_API_KEY`, `NEXTAUTH_SECRET
 Triggered on push/PR to `main`. Three parallel jobs:
 1. **backend**: uv sync → `uv run python -m pytest tests/ -v`
 2. **frontend**: pnpm install → `pnpm exec biome ci .` → `pnpm test` → `pnpm build`
-3. **docker**: `docker compose build` → `docker compose up -d` → health checks → `docker compose down -v`
+3. **docker**: `docker compose build` + Trivy scan (report-only). Full health check (`up -d` → wait → verify) runs **only on push to main**.
+
+## CD pipeline (`.github/workflows/deploy.yml`)
+
+Triggered after CI passes on `main`. Two parallel jobs:
+1. **Vercel**: frontend deploy via Vercel CLI (`--prod`)
+2. **Railway**: backend deploy via Railway CLI
+
+Requires repo secrets: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `RAILWAY_TOKEN`, `RAILWAY_SERVICE_ID`.
 
 ## Issue workflow
 


### PR DESCRIPTION
## 概要

CI通過後に自動で本番環境へデプロイするCDパイプラインを構築。

## 変更内容

- **`.github/workflows/deploy.yml`**: CI完了をトリガーにVercel + Railwayへ自動デプロイ
  - Vercel: Vercel CLI で `--prod` デプロイ
  - Railway: `railway up --service=... --ci` でデプロイ
  - 両ジョブ並列実行、CIがsuccessの場合のみ動作
- **AGENTS.md**: CDパイプラインセクションを追記

## 必要なRepository Secrets

| Secret | 用途 |
|--------|------|
| `VERCEL_TOKEN` | Vercel認証トークン |
| `VERCEL_ORG_ID` | Vercel Organization ID (scope) |
| `RAILWAY_TOKEN` | Railwayデプロイトークン |
| `RAILWAY_SERVICE_ID` | RailwayサービスID |

## デプロイフロー

`mainブランチにマージ → CI通過 → Vercel + Railwayに同時デプロイ`