### PR TITLE
⬆️ Dependabotによる依存関係自動更新設定 (#42)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "backend"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    versioning-strategy: increase
+    labels:
+      - "dependencies"
+      - "frontend"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "ci"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,12 @@ Triggered after CI passes on `main`. Two parallel jobs:
 
 Requires repo secrets: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `RAILWAY_TOKEN`, `RAILWAY_SERVICE_ID`.
 
+## Dependabot (`.github/dependabot.yml`)
+
+- **backend** (`pip`): weekly, label `dependencies` + `backend`
+- **frontend** (`npm`): weekly, label `dependencies` + `frontend`, versioning-strategy: increase
+- **GitHub Actions**: monthly, label `dependencies` + `ci`
+
 ## Issue workflow
 
 1. Branch name: `feature/<issue_number>`. Create from the current branch and start working.


### PR DESCRIPTION
## 概要

依存パッケージの更新を自動検出しPRを作成するDependabot設定を追加。

## 変更内容

- **`.github/dependabot.yml`**: 3つのecosystemを監視
  - pip (backend): 週次、10 PR制限
  - npm (frontend): 週次、versioning-strategy: increase
  - GitHub Actions: 月次
- **AGENTS.md**: Dependabot設定セクションを追記

## 動作

各ecosystemのスケジュールに従って自動的に依存関係更新のPRが作成される。CIで検証可能。