### PR TITLE
✨ タグ削除機能 + OCR未使用コード削除 (#68, #72)

### DIFF
--- a/backend/routers/tags.py
+++ b/backend/routers/tags.py
@@ -27,3 +27,14 @@ def create_tag(tag: TagCreate, db: Session = Depends(get_db)):
     db.commit()
     db.refresh(new_tag)
     return new_tag
+
+
+@router.delete("/tags/{tag_id}", status_code=204)
+def delete_tag(tag_id: int, db: Session = Depends(get_db)):
+    """タグを削除"""
+    tag = db.query(Tag).filter(Tag.id == tag_id).first()
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+
+    db.delete(tag)
+    db.commit()

--- a/backend/tests/test_tags.py
+++ b/backend/tests/test_tags.py
@@ -29,3 +29,23 @@ def test_list_tags_after_creation(client):
     names = [t["name"] for t in data]
     assert "微分積分" in names
     assert "確率" in names
+
+
+def test_delete_tag(client):
+    resp = client.post("/api/tags", json={"name": "削除テスト"})
+    assert resp.status_code == 201
+    tag_id = resp.json()["id"]
+
+    delete_resp = client.delete(f"/api/tags/{tag_id}")
+    assert delete_resp.status_code == 204
+
+    list_resp = client.get("/api/tags")
+    names = [t["name"] for t in list_resp.json()]
+    assert "削除テスト" not in names
+
+
+def test_delete_nonexistent_tag(client):
+    resp = client.delete("/api/tags/9999")
+    assert resp.status_code == 404
+    assert resp.json()["error"] == "HTTP_ERROR"
+    assert "not found" in resp.json()["message"].lower()

--- a/frontend/app/tags/page.tsx
+++ b/frontend/app/tags/page.tsx
@@ -7,6 +7,7 @@ import { TagCard } from "@/components/tag-card";
 import { problemsApi, tagsApi } from "@/lib/api";
 
 interface TagWithCount {
+	id: number;
 	tag: string;
 	count: number;
 }
@@ -14,6 +15,7 @@ interface TagWithCount {
 export default function TagsPage() {
 	const [tagStats, setTagStats] = useState<TagWithCount[]>([]);
 	const [isLoading, setIsLoading] = useState(true);
+	const [deletingTag, setDeletingTag] = useState<string | null>(null);
 
 	useEffect(() => {
 		const fetchTagStats = async () => {
@@ -24,16 +26,24 @@ export default function TagsPage() {
 					problemsApi.getProblems({ limit: 1000 }),
 				]);
 
-				const stats = new Map<string, number>();
-				problemsData.problems.forEach((problem) => {
-					problem.tags.forEach((tag) => {
-						stats.set(tag.name, (stats.get(tag.name) || 0) + 1);
-					});
-				});
+				const tagMap = new Map<
+					string,
+					{ id: number; tag: string; count: number }
+				>();
+				for (const t of tags) {
+					tagMap.set(t.name, { id: t.id, tag: t.name, count: 0 });
+				}
 
-				const tagStatsArray = Array.from(stats.entries())
-					.map(([tag, count]) => ({ tag, count }))
-					.sort((a, b) => b.count - a.count);
+				for (const problem of problemsData.problems) {
+					for (const tag of problem.tags) {
+						const entry = tagMap.get(tag.name);
+						if (entry) entry.count++;
+					}
+				}
+
+				const tagStatsArray = Array.from(tagMap.values()).sort(
+					(a, b) => b.count - a.count,
+				);
 
 				setTagStats(tagStatsArray);
 			} catch (error) {
@@ -45,6 +55,22 @@ export default function TagsPage() {
 
 		fetchTagStats();
 	}, []);
+
+	const handleDeleteTag = async (tag: string) => {
+		if (!confirm(`"${tag}" を削除してもよろしいですか？`)) return;
+		setDeletingTag(tag);
+		try {
+			const entry = tagStats.find((t) => t.tag === tag);
+			if (entry) {
+				await tagsApi.deleteTag(entry.id);
+				setTagStats((prev) => prev.filter((t) => t.tag !== tag));
+			}
+		} catch (error) {
+			console.error("Failed to delete tag:", error);
+		} finally {
+			setDeletingTag(null);
+		}
+	};
 
 	return (
 		<div className="min-h-screen flex flex-col">
@@ -77,8 +103,14 @@ export default function TagsPage() {
 						</div>
 					) : (
 						<div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-							{tagStats.map(({ tag, count }) => (
-								<TagCard key={tag} tag={tag} count={count} />
+							{tagStats.map(({ tag, count, id }) => (
+								<TagCard
+									key={tag}
+									tag={tag}
+									count={count}
+									onDelete={handleDeleteTag}
+									isDeleting={deletingTag === tag}
+								/>
 							))}
 						</div>
 					)}

--- a/frontend/components/tag-card.tsx
+++ b/frontend/components/tag-card.tsx
@@ -1,33 +1,56 @@
-import { Tag } from "lucide-react";
+import { Loader2, Tag, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 interface TagCardProps {
 	tag: string;
 	count: number;
+	onDelete?: (tag: string) => void;
+	isDeleting?: boolean;
 }
 
-export function TagCard({ tag, count }: TagCardProps) {
+export function TagCard({ tag, count, onDelete, isDeleting }: TagCardProps) {
 	return (
-		<Link href={`/problems?tag=${encodeURIComponent(tag)}`}>
-			<Card className="h-full hover:border-primary/50 transition-colors cursor-pointer">
-				<CardHeader>
-					<div className="flex items-center gap-3">
-						<div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
-							<Tag className="h-5 w-5" />
+		<div className="relative group">
+			<Link href={`/problems?tag=${encodeURIComponent(tag)}`}>
+				<Card className="h-full hover:border-primary/50 transition-colors cursor-pointer">
+					<CardHeader>
+						<div className="flex items-center gap-3">
+							<div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+								<Tag className="h-5 w-5" />
+							</div>
+							<CardTitle className="text-lg">{tag}</CardTitle>
 						</div>
-						<CardTitle className="text-lg">{tag}</CardTitle>
-					</div>
-				</CardHeader>
-				<CardContent>
-					<div className="flex items-center gap-2">
-						<Badge variant="secondary" className="text-sm">
-							{count}件の問題
-						</Badge>
-					</div>
-				</CardContent>
-			</Card>
-		</Link>
+					</CardHeader>
+					<CardContent>
+						<div className="flex items-center gap-2">
+							<Badge variant="secondary" className="text-sm">
+								{count}件の問題
+							</Badge>
+						</div>
+					</CardContent>
+				</Card>
+			</Link>
+			{onDelete && (
+				<Button
+					variant="ghost"
+					size="icon"
+					className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-destructive"
+					onClick={(e) => {
+						e.preventDefault();
+						onDelete(tag);
+					}}
+					disabled={isDeleting}
+				>
+					{isDeleting ? (
+						<Loader2 className="h-4 w-4 animate-spin" />
+					) : (
+						<Trash2 className="h-4 w-4" />
+					)}
+				</Button>
+			)}
+		</div>
 	);
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -280,27 +280,3 @@ export const uploadApi = {
 		return response.json();
 	},
 };
-
-export const ocrApi = {
-	async extractText(file: File): Promise<{ text: string; filename: string }> {
-		const formData = new FormData();
-		formData.append("file", file);
-
-		const response = await fetchWithRetry(
-			`${API_URL}/api/ocr`,
-			{
-				method: "POST",
-				body: formData,
-			},
-			DEFAULT_TIMEOUT,
-			0,
-		);
-		if (!response.ok)
-			throw new ApiError(
-				response.status,
-				"OCR_FAILED",
-				"Failed to extract text",
-			);
-		return response.json();
-	},
-};


### PR DESCRIPTION
## 概要

タグ削除機能の実装と未使用コードの整理を行いました。

## 変更内容

### #68: タグ削除機能

#### バックエンド
- DELETE /api/tags/{id} エンドポイント追加
- CASCADE で problem_tags の関連レコードも自動削除

#### フロントエンド
- タグカードに削除ボタン（ホバー表示 + 確認ダイアログ）
- タグ一覧のデータ構造整理（ID保持）

#### テスト
- test_delete_tag: 削除後一覧に含まれないことを確認
- test_delete_nonexistent_tag: 存在しないタグで404を確認

### #72: OCR API未使用コード削除
- frontend/lib/api.ts から未使用の ocrApi を削除（対応バックエンドエンドポイントなし）