### PR TITLE
✨ 解説生成/編集 + ページネーション (#69, #70)

### DIFF
--- a/frontend/app/problems/[id]/page.tsx
+++ b/frontend/app/problems/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowLeft, Calendar } from "lucide-react";
+import { ArrowLeft, Calendar, Edit3, Loader2, Sparkles } from "lucide-react";
 import Link from "next/link";
 import { notFound, useParams } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -9,6 +9,7 @@ import { SolutionDisplay } from "@/components/solution-display";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Textarea } from "@/components/ui/textarea";
 import { type Problem, problemsApi } from "@/lib/api";
 
 export default function ProblemDetailPage() {
@@ -17,6 +18,10 @@ export default function ProblemDetailPage() {
 	const [problem, setProblem] = useState<Problem | null>(null);
 	const [isLoading, setIsLoading] = useState(true);
 	const [notFoundError, setNotFoundError] = useState(false);
+	const [isGenerating, setIsGenerating] = useState(false);
+	const [isEditing, setIsEditing] = useState(false);
+	const [editText, setEditText] = useState("");
+	const [isSaving, setIsSaving] = useState(false);
 
 	useEffect(() => {
 		const fetchProblem = async () => {
@@ -24,6 +29,7 @@ export default function ProblemDetailPage() {
 				setIsLoading(true);
 				const data = await problemsApi.getProblem(Number(id));
 				setProblem(data);
+				setEditText(data.answer || "");
 			} catch (error) {
 				console.error("[v0] Error fetching problem:", error);
 				setNotFoundError(true);
@@ -34,6 +40,46 @@ export default function ProblemDetailPage() {
 
 		fetchProblem();
 	}, [id]);
+
+	const handleGenerate = async () => {
+		if (!problem) return;
+		setIsGenerating(true);
+		try {
+			const { answer } = await problemsApi.generateAnswer(problem.id);
+			setProblem({ ...problem, answer });
+			setEditText(answer);
+		} catch (error) {
+			console.error("Failed to generate solution:", error);
+		} finally {
+			setIsGenerating(false);
+		}
+	};
+
+	const handleStartEdit = () => {
+		setEditText(problem?.answer || "");
+		setIsEditing(true);
+	};
+
+	const handleCancelEdit = () => {
+		setIsEditing(false);
+		setEditText(problem?.answer || "");
+	};
+
+	const handleSaveEdit = async () => {
+		if (!problem) return;
+		setIsSaving(true);
+		try {
+			const updated = await problemsApi.updateProblem(problem.id, {
+				answer: editText,
+			});
+			setProblem(updated);
+			setIsEditing(false);
+		} catch (error) {
+			console.error("Failed to update solution:", error);
+		} finally {
+			setIsSaving(false);
+		}
+	};
 
 	if (notFoundError) {
 		notFound();
@@ -113,7 +159,82 @@ export default function ProblemDetailPage() {
 							</CardContent>
 						</Card>
 
-						{problem.answer && <SolutionDisplay solution={problem.answer} />}
+						{problem.answer && !isEditing && (
+							<div className="relative">
+								<SolutionDisplay solution={problem.answer} />
+								<Button
+									variant="outline"
+									size="sm"
+									className="absolute top-4 right-4 gap-2"
+									onClick={handleStartEdit}
+								>
+									<Edit3 className="h-4 w-4" />
+									編集
+								</Button>
+							</div>
+						)}
+
+						{isEditing && (
+							<Card className="border-primary/20">
+								<CardHeader>
+									<CardTitle className="flex items-center gap-2 text-xl">
+										<div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 text-primary">
+											<Sparkles className="h-4 w-4" />
+										</div>
+										AI生成の解説（編集中）
+									</CardTitle>
+								</CardHeader>
+								<CardContent className="space-y-4">
+									<Textarea
+										value={editText}
+										onChange={(e) => setEditText(e.target.value)}
+										className="min-h-[200px] font-mono text-sm"
+									/>
+									<div className="flex gap-2 justify-end">
+										<Button
+											variant="outline"
+											onClick={handleCancelEdit}
+											disabled={isSaving}
+										>
+											キャンセル
+										</Button>
+										<Button onClick={handleSaveEdit} disabled={isSaving}>
+											{isSaving ? (
+												<>
+													<Loader2 className="h-4 w-4 mr-2 animate-spin" />
+													保存中...
+												</>
+											) : (
+												"保存"
+											)}
+										</Button>
+									</div>
+								</CardContent>
+							</Card>
+						)}
+
+						{!problem.answer && !isEditing && (
+							<div className="flex justify-center">
+								<Button
+									size="lg"
+									className="gap-2"
+									onClick={handleGenerate}
+									disabled={isGenerating}
+								>
+									{isGenerating ? (
+										<>
+											<Loader2 className="h-5 w-5 animate-spin" />
+											解説を生成中...
+										</>
+									) : (
+										<>
+											<Sparkles className="h-5 w-5" />
+											AIで解説を生成
+										</>
+									)}
+								</Button>
+							</div>
+						)}
 					</div>
 				</div>
 			</main>

--- a/frontend/app/problems/page.tsx
+++ b/frontend/app/problems/page.tsx
@@ -2,40 +2,56 @@
 
 import { Plus } from "lucide-react";
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { Header } from "@/components/header";
 import { ProblemCard } from "@/components/problem-card";
 import { ProblemFilters } from "@/components/problem-filters";
 import { Button } from "@/components/ui/button";
+import {
+	Pagination,
+	PaginationContent,
+	PaginationEllipsis,
+	PaginationItem,
+	PaginationLink,
+	PaginationNext,
+	PaginationPrevious,
+} from "@/components/ui/pagination";
 import { useToast } from "@/hooks/use-toast";
 import { ApiError, type Problem, problemsApi, tagsApi } from "@/lib/api";
 
+const PAGE_SIZE = 12;
+
 export default function ProblemsPage() {
+	const router = useRouter();
 	const searchParams = useSearchParams();
 	const { toast } = useToast();
-	const [search, setSearch] = useState("");
-	const [selectedTag, setSelectedTag] = useState<string | null>(null);
 	const [problems, setProblems] = useState<Problem[]>([]);
+	const [total, setTotal] = useState(0);
 	const [availableTags, setAvailableTags] = useState<string[]>([]);
 	const [isLoading, setIsLoading] = useState(true);
 
-	useEffect(() => {
-		const tagParam = searchParams.get("tag");
-		if (tagParam) {
-			setSelectedTag(tagParam);
-		}
-	}, [searchParams]);
+	const page = Number(searchParams.get("page")) || 1;
+	const search = searchParams.get("search") || "";
+	const selectedTag = searchParams.get("tag") || null;
+
+	const totalPages = Math.ceil(total / PAGE_SIZE);
 
 	useEffect(() => {
 		const fetchData = async () => {
 			try {
 				setIsLoading(true);
 				const [problemsData, tagsData] = await Promise.all([
-					problemsApi.getProblems({ limit: 100 }),
+					problemsApi.getProblems({
+						skip: (page - 1) * PAGE_SIZE,
+						limit: PAGE_SIZE,
+						tag: selectedTag || undefined,
+						search: search || undefined,
+					}),
 					tagsApi.getTags(),
 				]);
 				setProblems(problemsData.problems);
+				setTotal(problemsData.total);
 				setAvailableTags(tagsData.map((tag) => tag.name));
 			} catch (error) {
 				console.error("[v0] Error fetching data:", error);
@@ -64,7 +80,29 @@ export default function ProblemsPage() {
 		};
 
 		fetchData();
-	}, [toast]);
+	}, [page, search, selectedTag, toast]);
+
+	const handleSearchChange = (value: string) => {
+		const params = new URLSearchParams(searchParams);
+		if (value) {
+			params.set("search", value);
+		} else {
+			params.delete("search");
+		}
+		params.set("page", "1");
+		router.push(`/problems?${params.toString()}`);
+	};
+
+	const handleTagFilter = (tag: string | null) => {
+		const params = new URLSearchParams(searchParams);
+		if (tag) {
+			params.set("tag", tag);
+		} else {
+			params.delete("tag");
+		}
+		params.set("page", "1");
+		router.push(`/problems?${params.toString()}`);
+	};
 
 	const handleDeleteProblem = async (id: number) => {
 		try {
@@ -99,20 +137,31 @@ export default function ProblemsPage() {
 		}
 	};
 
-	const filteredProblems = useMemo(() => {
-		return problems.filter((problem) => {
-			const matchesSearch =
-				search === "" ||
-				problem.title.toLowerCase().includes(search.toLowerCase()) ||
-				problem.content.toLowerCase().includes(search.toLowerCase());
+	const buildPageUrl = (p: number) => {
+		const params = new URLSearchParams(searchParams);
+		params.set("page", String(p));
+		return `/problems?${params.toString()}`;
+	};
 
-			const matchesTag =
-				selectedTag === null ||
-				problem.tags.some((tag) => tag.name === selectedTag);
-
-			return matchesSearch && matchesTag;
-		});
-	}, [problems, search, selectedTag]);
+	const paginationItems = useMemo(() => {
+		const items: (number | "ellipsis")[] = [];
+		if (totalPages <= 5) {
+			for (let i = 1; i <= totalPages; i++) items.push(i);
+		} else {
+			items.push(1);
+			if (page > 3) items.push("ellipsis");
+			for (
+				let i = Math.max(2, page - 1);
+				i <= Math.min(totalPages - 1, page + 1);
+				i++
+			) {
+				items.push(i);
+			}
+			if (page < totalPages - 2) items.push("ellipsis");
+			items.push(totalPages);
+		}
+		return items;
+	}, [page, totalPages]);
 
 	return (
 		<div className="min-h-screen flex flex-col">
@@ -138,10 +187,11 @@ export default function ProblemsPage() {
 
 					<div className="mb-8">
 						<ProblemFilters
-							onSearchChange={setSearch}
-							onTagFilter={setSelectedTag}
+							onSearchChange={handleSearchChange}
+							onTagFilter={handleTagFilter}
 							availableTags={availableTags}
 							selectedTag={selectedTag}
+							initialSearch={search}
 						/>
 					</div>
 
@@ -149,22 +199,59 @@ export default function ProblemsPage() {
 						<div className="text-center py-12">
 							<p className="text-muted-foreground">読み込み中...</p>
 						</div>
-					) : filteredProblems.length === 0 ? (
+					) : problems.length === 0 ? (
 						<div className="text-center py-12">
 							<p className="text-muted-foreground">
 								問題が見つかりませんでした。
 							</p>
 						</div>
 					) : (
-						<div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-							{filteredProblems.map((problem) => (
-								<ProblemCard
-									key={problem.id}
-									problem={problem}
-									onDelete={handleDeleteProblem}
-								/>
-							))}
-						</div>
+						<>
+							<div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+								{problems.map((problem) => (
+									<ProblemCard
+										key={problem.id}
+										problem={problem}
+										onDelete={handleDeleteProblem}
+									/>
+								))}
+							</div>
+
+							{totalPages > 1 && (
+								<div className="mt-8 flex justify-center">
+									<Pagination>
+										<PaginationContent>
+											{page > 1 && (
+												<PaginationItem>
+													<PaginationPrevious href={buildPageUrl(page - 1)} />
+												</PaginationItem>
+											)}
+											{paginationItems.map((item, i) =>
+												item === "ellipsis" ? (
+													<PaginationItem key={`e${i}`}>
+														<PaginationEllipsis />
+													</PaginationItem>
+												) : (
+													<PaginationItem key={item}>
+														<PaginationLink
+															href={buildPageUrl(item)}
+															isActive={item === page}
+														>
+															{item}
+														</PaginationLink>
+													</PaginationItem>
+												),
+											)}
+											{page < totalPages && (
+												<PaginationItem>
+													<PaginationNext href={buildPageUrl(page + 1)} />
+												</PaginationItem>
+											)}
+										</PaginationContent>
+									</Pagination>
+								</div>
+							)}
+						</>
 					)}
 				</div>
 			</main>

--- a/frontend/components/problem-filters.tsx
+++ b/frontend/components/problem-filters.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Search, X } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 
@@ -10,6 +10,7 @@ interface ProblemFiltersProps {
 	onTagFilter: (tag: string | null) => void;
 	availableTags: string[];
 	selectedTag: string | null;
+	initialSearch?: string;
 }
 
 export function ProblemFilters({
@@ -17,8 +18,13 @@ export function ProblemFilters({
 	onTagFilter,
 	availableTags,
 	selectedTag,
+	initialSearch,
 }: ProblemFiltersProps) {
-	const [search, setSearch] = useState("");
+	const [search, setSearch] = useState(initialSearch || "");
+
+	useEffect(() => {
+		setSearch(initialSearch || "");
+	}, [initialSearch]);
 
 	const handleSearchChange = (value: string) => {
 		setSearch(value);

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -32,6 +32,13 @@ export interface CreateProblemData {
 	tag_ids: number[];
 }
 
+export interface UpdateProblemData {
+	title?: string;
+	content?: string;
+	answer?: string;
+	tag_ids?: number[];
+}
+
 export class ApiError extends Error {
 	status: number;
 	code: string;
@@ -194,10 +201,7 @@ export const problemsApi = {
 		return response.json();
 	},
 
-	async updateProblem(
-		id: number,
-		data: Partial<CreateProblemData>,
-	): Promise<Problem> {
+	async updateProblem(id: number, data: UpdateProblemData): Promise<Problem> {
 		const response = await fetchWithRetry(
 			`${API_URL}/api/problems/${id}`,
 			{


### PR DESCRIPTION
## 概要

問題詳細の改善と一覧パフォーマンスの向上を行いました。

## #69: 解説生成ボタン / 編集機能
- 解説がない問題に「AIで解説を生成」ボタンを表示
- 解説がある場合に「編集」ボタン（インラインTextarea編集）
- UpdateProblemData インターフェース新設

## #70: サーバーサイドページネーション
- 検索・タグフィルターをクエリパラメータ化（URL同期、ページ遷移保持）
- 1ページ12件のサーバーサイドページネーション
- shadcn/ui Pagination コンポーネントでページネーションUI
- ProblemFilters に initialSearch 対応