### PR TITLE
✨ CORS設定を環境変数で制限可能に (#71)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,6 +12,10 @@ OPENROUTER_API_KEY=
 # OpenRouter AIモデル
 OPENROUTER_AI_MODEL=
 
+# CORS許可オリジン（カンマ区切りで複数指定可、省略時は全許可）
+# 例: CORS_ORIGINS="http://localhost:3000,https://example.com"
+CORS_ORIGINS=*
+
 # AI リトライ設定（省略時はデフォルト値使用）
 AI_MAX_RETRIES=3
 AI_RETRY_BASE_DELAY=1.0

--- a/backend/config.py
+++ b/backend/config.py
@@ -11,6 +11,10 @@ class Settings(BaseSettings):
     openrouter_api_key: str
     openrouter_ai_model: str
 
+    # CORS
+    # カンマ区切りで複数指定可。デフォルトは全許可（開発用）
+    cors_origins: str = "*"
+
     # AI リトライ設定
     ai_max_retries: int = 3
     ai_retry_base_delay: float = 1.0

--- a/backend/main.py
+++ b/backend/main.py
@@ -29,10 +29,11 @@ app = FastAPI(
     version="1.0.0"
 )
 
-# CORS設定
+# CORS設定（カンマ区切りで複数指定可、デフォルトは全許可）
+origins = [o.strip() for o in settings.cors_origins.split(",")]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- CORS許可オリジンを環境変数 `CORS_ORIGINS` で制限可能に
- カンマ区切りで複数オリジン指定に対応
- `.env.example` に設定例を追加

## Changes
- `backend/config.py`: `cors_origins: str = "*"` を追加（デフォルトは全許可）
- `backend/main.py`: `settings.cors_origins` をパースして CORSMiddleware に渡す
- `backend/.env.example`: CORS_ORIGINS の設定例を追記