### PR TITLE
✨ 検索入力にデバウンス(300ms)を追加 (#81)

### DIFF
--- a/frontend/components/problem-filters.tsx
+++ b/frontend/components/problem-filters.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Search, X } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 
@@ -21,6 +21,7 @@ export function ProblemFilters({
 	initialSearch,
 }: ProblemFiltersProps) {
 	const [search, setSearch] = useState(initialSearch || "");
+	const debounceRef = useRef<ReturnType<typeof setTimeout>>();
 
 	useEffect(() => {
 		setSearch(initialSearch || "");
@@ -28,8 +29,15 @@ export function ProblemFilters({
 
 	const handleSearchChange = (value: string) => {
 		setSearch(value);
-		onSearchChange(value);
+		if (debounceRef.current) clearTimeout(debounceRef.current);
+		debounceRef.current = setTimeout(() => onSearchChange(value), 300);
 	};
+
+	useEffect(() => {
+		return () => {
+			if (debounceRef.current) clearTimeout(debounceRef.current);
+		};
+	}, []);
 
 	return (
 		<div className="space-y-4">


### PR DESCRIPTION
## Summary
problem-filters.tsx の検索入力を300msデバウンス。キー入力ごとに router.push が走るのを防ぎ、無駄な再レンダリングと履歴汚染を抑制。