### PR TITLE
✨ error.tsx / not-found.tsx を追加 (#76)

### DIFF
--- a/frontend/app/error.tsx
+++ b/frontend/app/error.tsx
@@ -12,6 +12,7 @@ import {
 	CardTitle,
 } from "@/components/ui/card";
 
+// biome-ignore lint/suspicious/noShadowRestrictedNames: Next.js convention
 export default function Error({
 	error,
 	reset,

--- a/frontend/app/error.tsx
+++ b/frontend/app/error.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardFooter,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+
+export default function Error({
+	error,
+	reset,
+}: {
+	error: Error & { digest?: string };
+	reset: () => void;
+}) {
+	useEffect(() => {
+		console.error("Page error:", error);
+	}, [error]);
+
+	return (
+		<div className="min-h-screen flex items-center justify-center p-4">
+			<Card className="w-full max-w-md">
+				<CardHeader>
+					<div className="flex items-center gap-2 text-destructive">
+						<AlertTriangle className="h-5 w-5" />
+						<CardTitle className="text-lg">
+							予期しないエラーが発生しました
+						</CardTitle>
+					</div>
+					<CardDescription>
+						アプリケーションで問題が発生しました。再読み込みをお試しください。
+					</CardDescription>
+				</CardHeader>
+				{error.digest && (
+					<CardContent>
+						<p className="text-xs text-muted-foreground">
+							Error ID: {error.digest}
+						</p>
+					</CardContent>
+				)}
+				<CardFooter>
+					<Button className="w-full gap-2" onClick={reset}>
+						<RefreshCw className="h-4 w-4" />
+						再読み込み
+					</Button>
+				</CardFooter>
+			</Card>
+		</div>
+	);
+}

--- a/frontend/app/global-error.tsx
+++ b/frontend/app/global-error.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function GlobalError({
+	error,
+	reset,
+}: {
+	error: Error & { digest?: string };
+	reset: () => void;
+}) {
+	return (
+		<html lang="ja">
+			<body className="font-sans">
+				<div className="min-h-screen flex items-center justify-center p-4">
+					<div className="w-full max-w-md text-center space-y-4">
+						<div className="flex justify-center text-destructive">
+							<AlertTriangle className="h-12 w-12" />
+						</div>
+						<h1 className="text-xl font-bold">
+							重大なエラーが発生しました
+						</h1>
+						<p className="text-muted-foreground text-sm">
+							アプリケーションの起動中に問題が発生しました。
+							しばらく待ってから再読み込みをお試しください。
+						</p>
+						{error.digest && (
+							<p className="text-xs text-muted-foreground">
+								Error ID: {error.digest}
+							</p>
+						)}
+						<Button className="gap-2" onClick={reset}>
+							<RefreshCw className="h-4 w-4" />
+							再読み込み
+						</Button>
+					</div>
+				</div>
+			</body>
+		</html>
+	);
+}

--- a/frontend/app/global-error.tsx
+++ b/frontend/app/global-error.tsx
@@ -3,6 +3,7 @@
 import { AlertTriangle, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
+// biome-ignore lint/suspicious/noShadowRestrictedNames: Next.js convention
 export default function GlobalError({
 	error,
 	reset,

--- a/frontend/app/global-error.tsx
+++ b/frontend/app/global-error.tsx
@@ -19,9 +19,7 @@ export default function GlobalError({
 						<div className="flex justify-center text-destructive">
 							<AlertTriangle className="h-12 w-12" />
 						</div>
-						<h1 className="text-xl font-bold">
-							重大なエラーが発生しました
-						</h1>
+						<h1 className="text-xl font-bold">重大なエラーが発生しました</h1>
 						<p className="text-muted-foreground text-sm">
 							アプリケーションの起動中に問題が発生しました。
 							しばらく待ってから再読み込みをお試しください。

--- a/frontend/app/not-found.tsx
+++ b/frontend/app/not-found.tsx
@@ -1,0 +1,34 @@
+import { FileQuestion } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardFooter,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+
+export default function NotFound() {
+	return (
+		<div className="min-h-screen flex items-center justify-center p-4">
+			<Card className="w-full max-w-md">
+				<CardHeader>
+					<div className="flex items-center gap-2 text-muted-foreground">
+						<FileQuestion className="h-5 w-5" />
+						<CardTitle className="text-lg">ページが見つかりません</CardTitle>
+					</div>
+					<CardDescription>
+						お探しのページは存在しないか、移動または削除された可能性があります。
+					</CardDescription>
+				</CardHeader>
+				<CardFooter>
+					<Button className="w-full" asChild>
+						<Link href="/">トップページに戻る</Link>
+					</Button>
+				</CardFooter>
+			</Card>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
- frontend/app/error.tsx: 汎用エラーページ（Error ID表示 + 再読み込みボタン）
- frontend/app/not-found.tsx: カスタム404ページ（トップページへのリンク）
- frontend/app/global-error.tsx: ルートレイアウト用エラーハンドリング