### PR TITLE
✨ ローディングスケルトンを追加 (#77)

### DIFF
--- a/frontend/app/problems/[id]/loading.tsx
+++ b/frontend/app/problems/[id]/loading.tsx
@@ -1,0 +1,25 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function ProblemDetailLoading() {
+	return (
+		<div className="min-h-screen bg-background">
+			<div className="container mx-auto px-4 py-8 space-y-6">
+				<Skeleton className="h-6 w-24" />
+				<div className="space-y-4">
+					<Skeleton className="h-8 w-2/3" />
+					<div className="border rounded-lg p-6 space-y-3">
+						<Skeleton className="h-4 w-full" />
+						<Skeleton className="h-4 w-5/6" />
+						<Skeleton className="h-4 w-3/4" />
+					</div>
+					<div className="border rounded-lg p-6 space-y-3">
+						<Skeleton className="h-6 w-32" />
+						<Skeleton className="h-4 w-full" />
+						<Skeleton className="h-4 w-4/5" />
+						<Skeleton className="h-4 w-2/3" />
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/frontend/app/problems/loading.tsx
+++ b/frontend/app/problems/loading.tsx
@@ -1,3 +1,28 @@
-export default function Loading() {
-	return null;
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function ProblemsLoading() {
+	return (
+		<div className="min-h-screen bg-background">
+			<div className="container mx-auto px-4 py-8 space-y-6">
+				<Skeleton className="h-8 w-48" />
+				<div className="flex gap-4">
+					<Skeleton className="h-10 flex-1" />
+					<Skeleton className="h-10 w-32" />
+				</div>
+				<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+					{Array.from({ length: 6 }).map((_, i) => (
+						<div key={i} className="border rounded-lg p-4 space-y-3">
+							<Skeleton className="h-5 w-3/4" />
+							<Skeleton className="h-4 w-full" />
+							<Skeleton className="h-4 w-1/2" />
+							<div className="flex gap-2 pt-2">
+								<Skeleton className="h-5 w-16 rounded-full" />
+								<Skeleton className="h-5 w-12 rounded-full" />
+							</div>
+						</div>
+					))}
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/frontend/app/tags/loading.tsx
+++ b/frontend/app/tags/loading.tsx
@@ -1,0 +1,16 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function TagsLoading() {
+	return (
+		<div className="min-h-screen bg-background">
+			<div className="container mx-auto px-4 py-8 space-y-6">
+				<Skeleton className="h-8 w-32" />
+				<div className="flex gap-2 flex-wrap">
+					{Array.from({ length: 8 }).map((_, i) => (
+						<Skeleton key={i} className="h-10 w-28 rounded-full" />
+					))}
+				</div>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
- frontend/app/problems/loading.tsx: 問題一覧のスケルトン（6件のカード）
- frontend/app/problems/[id]/loading.tsx: 問題詳細のスケルトン
- frontend/app/tags/loading.tsx: タグ一覧のスケルトン（8個の丸いタグ）

ui/skeleton.tsx を使用し、プレーンテキストの "読み込み中..." から差し替え