### PR TITLE
✨ タグ更新エンドポイント + インライン編集UI (#78)

### DIFF
--- a/backend/routers/tags.py
+++ b/backend/routers/tags.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 from typing import List
 
 from backend.models import Tag
-from backend.schemas import TagCreate, TagSchema
+from backend.schemas import TagCreate, TagSchema, TagUpdate
 from backend.database import get_db
 
 router = APIRouter()
@@ -27,6 +27,23 @@ def create_tag(tag: TagCreate, db: Session = Depends(get_db)):
     db.commit()
     db.refresh(new_tag)
     return new_tag
+
+
+@router.put("/tags/{tag_id}", response_model=TagSchema)
+def update_tag(tag_id: int, tag: TagUpdate, db: Session = Depends(get_db)):
+    """タグ名を更新"""
+    db_tag = db.query(Tag).filter(Tag.id == tag_id).first()
+    if not db_tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+
+    existing = db.query(Tag).filter(Tag.name == tag.name, Tag.id != tag_id).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="Tag with this name already exists")
+
+    db_tag.name = tag.name
+    db.commit()
+    db.refresh(db_tag)
+    return db_tag
 
 
 @router.delete("/tags/{tag_id}", status_code=204)

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -1,6 +1,6 @@
 from backend.schemas.error import ErrorResponse
 from backend.schemas.problem import ProblemBase, ProblemCreate, ProblemUpdate, ProblemSchema, ProblemList
-from backend.schemas.tag import TagBase, TagCreate, TagSchema
+from backend.schemas.tag import TagBase, TagCreate, TagSchema, TagUpdate
 
 __all__ = [
     "ErrorResponse",
@@ -12,4 +12,5 @@ __all__ = [
     "TagBase",
     "TagCreate",
     "TagSchema",
+    "TagUpdate",
 ]

--- a/backend/schemas/tag.py
+++ b/backend/schemas/tag.py
@@ -10,6 +10,10 @@ class TagCreate(TagBase):
     pass
 
 
+class TagUpdate(BaseModel):
+    name: str
+
+
 class TagSchema(TagBase):
     id: int
 

--- a/backend/tests/test_tags.py
+++ b/backend/tests/test_tags.py
@@ -44,6 +44,34 @@ def test_delete_tag(client):
     assert "削除テスト" not in names
 
 
+def test_update_tag(client):
+    resp = client.post("/api/tags", json={"name": "更新前"})
+    tag_id = resp.json()["id"]
+
+    resp = client.put(f"/api/tags/{tag_id}", json={"name": "更新後"})
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "更新後"
+
+    list_resp = client.get("/api/tags")
+    names = [t["name"] for t in list_resp.json()]
+    assert "更新前" not in names
+    assert "更新後" in names
+
+
+def test_update_nonexistent_tag(client):
+    resp = client.put("/api/tags/9999", json={"name": "nonexistent"})
+    assert resp.status_code == 404
+
+
+def test_update_tag_duplicate(client):
+    client.post("/api/tags", json={"name": "代数"})
+    tag2 = client.post("/api/tags", json={"name": "幾何"}).json()
+
+    resp = client.put(f"/api/tags/{tag2['id']}", json={"name": "代数"})
+    assert resp.status_code == 400
+    assert "already exists" in resp.json()["message"].lower()
+
+
 def test_delete_nonexistent_tag(client):
     resp = client.delete("/api/tags/9999")
     assert resp.status_code == 404

--- a/frontend/app/tags/page.tsx
+++ b/frontend/app/tags/page.tsx
@@ -64,9 +64,7 @@ export default function TagsPage() {
 			if (entry) {
 				await tagsApi.updateTag(entry.id, newName);
 				setTagStats((prev) =>
-					prev.map((t) =>
-						t.tag === oldTag ? { ...t, tag: newName } : t,
-					),
+					prev.map((t) => (t.tag === oldTag ? { ...t, tag: newName } : t)),
 				);
 			}
 		} catch (error) {

--- a/frontend/app/tags/page.tsx
+++ b/frontend/app/tags/page.tsx
@@ -16,6 +16,7 @@ export default function TagsPage() {
 	const [tagStats, setTagStats] = useState<TagWithCount[]>([]);
 	const [isLoading, setIsLoading] = useState(true);
 	const [deletingTag, setDeletingTag] = useState<string | null>(null);
+	const [updatingTag, setUpdatingTag] = useState<string | null>(null);
 
 	useEffect(() => {
 		const fetchTagStats = async () => {
@@ -55,6 +56,25 @@ export default function TagsPage() {
 
 		fetchTagStats();
 	}, []);
+
+	const handleUpdateTag = async (oldTag: string, newName: string) => {
+		setUpdatingTag(oldTag);
+		try {
+			const entry = tagStats.find((t) => t.tag === oldTag);
+			if (entry) {
+				await tagsApi.updateTag(entry.id, newName);
+				setTagStats((prev) =>
+					prev.map((t) =>
+						t.tag === oldTag ? { ...t, tag: newName } : t,
+					),
+				);
+			}
+		} catch (error) {
+			console.error("Failed to update tag:", error);
+		} finally {
+			setUpdatingTag(null);
+		}
+	};
 
 	const handleDeleteTag = async (tag: string) => {
 		if (!confirm(`"${tag}" を削除してもよろしいですか？`)) return;
@@ -109,7 +129,9 @@ export default function TagsPage() {
 									tag={tag}
 									count={count}
 									onDelete={handleDeleteTag}
+									onUpdate={handleUpdateTag}
 									isDeleting={deletingTag === tag}
+									isUpdating={updatingTag === tag}
 								/>
 							))}
 						</div>

--- a/frontend/components/tag-card.tsx
+++ b/frontend/components/tag-card.tsx
@@ -1,55 +1,140 @@
-import { Loader2, Tag, Trash2 } from "lucide-react";
+import { Check, Loader2, Pencil, Tag, Trash2, X } from "lucide-react";
 import Link from "next/link";
+import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 
 interface TagCardProps {
 	tag: string;
 	count: number;
 	onDelete?: (tag: string) => void;
+	onUpdate?: (oldTag: string, newName: string) => void;
 	isDeleting?: boolean;
+	isUpdating?: boolean;
 }
 
-export function TagCard({ tag, count, onDelete, isDeleting }: TagCardProps) {
+export function TagCard({
+	tag,
+	count,
+	onDelete,
+	onUpdate,
+	isDeleting,
+	isUpdating,
+}: TagCardProps) {
+	const [editing, setEditing] = useState(false);
+	const [editValue, setEditValue] = useState(tag);
+
+	const handleSave = () => {
+		const trimmed = editValue.trim();
+		if (trimmed && trimmed !== tag && onUpdate) {
+			onUpdate(tag, trimmed);
+		}
+		setEditing(false);
+	};
+
+	const handleCancel = () => {
+		setEditValue(tag);
+		setEditing(false);
+	};
+
 	return (
 		<div className="relative group">
-			<Link href={`/problems?tag=${encodeURIComponent(tag)}`}>
-				<Card className="h-full hover:border-primary/50 transition-colors cursor-pointer">
+			{editing ? (
+				<Card className="h-full">
 					<CardHeader>
-						<div className="flex items-center gap-3">
-							<div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
-								<Tag className="h-5 w-5" />
-							</div>
-							<CardTitle className="text-lg">{tag}</CardTitle>
+						<div className="flex items-center gap-2">
+							<Input
+								value={editValue}
+								onChange={(e) => setEditValue(e.target.value)}
+								onKeyDown={(e) => {
+									if (e.key === "Enter") handleSave();
+									if (e.key === "Escape") handleCancel();
+								}}
+								className="text-lg font-semibold"
+								autoFocus
+							/>
 						</div>
 					</CardHeader>
 					<CardContent>
-						<div className="flex items-center gap-2">
-							<Badge variant="secondary" className="text-sm">
-								{count}件の問題
-							</Badge>
+						<div className="flex gap-2">
+							<Button size="sm" onClick={handleSave} disabled={isUpdating}>
+								{isUpdating ? (
+									<Loader2 className="h-4 w-4 animate-spin" />
+								) : (
+									<Check className="h-4 w-4" />
+								)}
+								保存
+							</Button>
+							<Button
+								size="sm"
+								variant="outline"
+								onClick={handleCancel}
+								disabled={isUpdating}
+							>
+								<X className="h-4 w-4" />
+								キャンセル
+							</Button>
 						</div>
 					</CardContent>
 				</Card>
-			</Link>
-			{onDelete && (
-				<Button
-					variant="ghost"
-					size="icon"
-					className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-destructive"
-					onClick={(e) => {
-						e.preventDefault();
-						onDelete(tag);
-					}}
-					disabled={isDeleting}
-				>
-					{isDeleting ? (
-						<Loader2 className="h-4 w-4 animate-spin" />
-					) : (
-						<Trash2 className="h-4 w-4" />
-					)}
-				</Button>
+			) : (
+				<>
+					<Link href={`/problems?tag=${encodeURIComponent(tag)}`}>
+						<Card className="h-full hover:border-primary/50 transition-colors cursor-pointer">
+							<CardHeader>
+								<div className="flex items-center gap-3">
+									<div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+										<Tag className="h-5 w-5" />
+									</div>
+									<CardTitle className="text-lg">{tag}</CardTitle>
+								</div>
+							</CardHeader>
+							<CardContent>
+								<div className="flex items-center gap-2">
+									<Badge variant="secondary" className="text-sm">
+										{count}件の問題
+									</Badge>
+								</div>
+							</CardContent>
+						</Card>
+					</Link>
+					<div className="absolute top-2 right-2 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+						{onUpdate && (
+							<Button
+								variant="ghost"
+								size="icon"
+								className="text-muted-foreground hover:text-primary"
+								onClick={(e) => {
+									e.preventDefault();
+									setEditValue(tag);
+									setEditing(true);
+								}}
+							>
+								<Pencil className="h-4 w-4" />
+							</Button>
+						)}
+						{onDelete && (
+							<Button
+								variant="ghost"
+								size="icon"
+								className="text-muted-foreground hover:text-destructive"
+								onClick={(e) => {
+									e.preventDefault();
+									onDelete(tag);
+								}}
+								disabled={isDeleting}
+							>
+								{isDeleting ? (
+									<Loader2 className="h-4 w-4 animate-spin" />
+								) : (
+									<Trash2 className="h-4 w-4" />
+								)}
+							</Button>
+						)}
+					</div>
+				</>
 			)}
 		</div>
 	);

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -257,6 +257,20 @@ export const tagsApi = {
 		return response.json();
 	},
 
+	async updateTag(id: number, name: string): Promise<Tag> {
+		const response = await fetchWithRetry(
+			`${API_URL}/api/tags/${id}`,
+			{
+				method: "PUT",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ name }),
+			},
+			DEFAULT_TIMEOUT,
+			0,
+		);
+		return response.json();
+	},
+
 	async deleteTag(id: number): Promise<void> {
 		await fetchWithRetry(
 			`${API_URL}/api/tags/${id}`,


### PR DESCRIPTION
## Summary
- backend: PUT /api/tags/{id} を追加（重複名チェック付き）
- frontend lib/api.ts: updateTag() を追加
- frontend components/tag-card.tsx: インライン編集モード（クリック→入力→保存）
- frontend app/tags/page.tsx: 更新ハンドラを追加