### PR TITLE
✨ トースト通知 + 問題削除UI + confirm→AlertDialog (#80)

### DIFF
--- a/frontend/app/problems/[id]/page.tsx
+++ b/frontend/app/problems/[id]/page.tsx
@@ -1,8 +1,19 @@
 "use client";
 
-import { ArrowLeft, Calendar, Edit3, Loader2, Sparkles } from "lucide-react";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { ArrowLeft, Calendar, Edit3, Loader2, Sparkles, Trash2 } from "lucide-react";
 import Link from "next/link";
-import { notFound, useParams } from "next/navigation";
+import { notFound, useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { Header } from "@/components/header";
 import { SolutionDisplay } from "@/components/solution-display";
@@ -11,8 +22,11 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Textarea } from "@/components/ui/textarea";
 import { type Problem, problemsApi } from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
 
 export default function ProblemDetailPage() {
+	const { toast } = useToast();
+	const router = useRouter();
 	const params = useParams();
 	const id = params.id as string;
 	const [problem, setProblem] = useState<Problem | null>(null);
@@ -22,6 +36,8 @@ export default function ProblemDetailPage() {
 	const [isEditing, setIsEditing] = useState(false);
 	const [editText, setEditText] = useState("");
 	const [isSaving, setIsSaving] = useState(false);
+	const [isDeleting, setIsDeleting] = useState(false);
+	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
 	useEffect(() => {
 		const fetchProblem = async () => {
@@ -41,6 +57,26 @@ export default function ProblemDetailPage() {
 		fetchProblem();
 	}, [id]);
 
+	const handleDelete = async () => {
+		if (!problem) return;
+		setIsDeleting(true);
+		try {
+			await problemsApi.deleteProblem(problem.id);
+			toast({ title: "問題を削除しました" });
+			router.push("/problems");
+		} catch (error) {
+			console.error("Failed to delete problem:", error);
+			toast({
+				title: "エラー",
+				description: "問題の削除に失敗しました。",
+				variant: "destructive",
+			});
+		} finally {
+			setIsDeleting(false);
+			setDeleteDialogOpen(false);
+		}
+	};
+
 	const handleGenerate = async () => {
 		if (!problem) return;
 		setIsGenerating(true);
@@ -48,8 +84,14 @@ export default function ProblemDetailPage() {
 			const { answer } = await problemsApi.generateAnswer(problem.id);
 			setProblem({ ...problem, answer });
 			setEditText(answer);
+			toast({ title: "解説を生成しました" });
 		} catch (error) {
 			console.error("Failed to generate solution:", error);
+			toast({
+				title: "エラー",
+				description: "解説の生成に失敗しました。",
+				variant: "destructive",
+			});
 		} finally {
 			setIsGenerating(false);
 		}
@@ -74,8 +116,14 @@ export default function ProblemDetailPage() {
 			});
 			setProblem(updated);
 			setIsEditing(false);
+			toast({ title: "解説を保存しました" });
 		} catch (error) {
 			console.error("Failed to update solution:", error);
+			toast({
+				title: "エラー",
+				description: "解説の保存に失敗しました。",
+				variant: "destructive",
+			});
 		} finally {
 			setIsSaving(false);
 		}
@@ -136,6 +184,38 @@ export default function ProblemDetailPage() {
 											))}
 										</div>
 									</div>
+									<AlertDialog
+										open={deleteDialogOpen}
+										onOpenChange={setDeleteDialogOpen}
+									>
+										<AlertDialogTrigger asChild>
+											<Button
+												variant="ghost"
+												size="icon"
+												className="text-muted-foreground hover:text-destructive"
+											>
+												<Trash2 className="h-4 w-4" />
+											</Button>
+										</AlertDialogTrigger>
+										<AlertDialogContent>
+											<AlertDialogHeader>
+												<AlertDialogTitle>問題を削除しますか？</AlertDialogTitle>
+												<AlertDialogDescription>
+													「{problem.title}」を削除してもよろしいですか？
+													この操作は元に戻せません。
+												</AlertDialogDescription>
+											</AlertDialogHeader>
+											<AlertDialogFooter>
+												<AlertDialogCancel>キャンセル</AlertDialogCancel>
+												<AlertDialogAction
+													onClick={handleDelete}
+													disabled={isDeleting}
+												>
+													{isDeleting ? "削除中..." : "削除"}
+												</AlertDialogAction>
+											</AlertDialogFooter>
+										</AlertDialogContent>
+									</AlertDialog>
 								</div>
 							</CardHeader>
 							<CardContent>

--- a/frontend/app/problems/[id]/page.tsx
+++ b/frontend/app/problems/[id]/page.tsx
@@ -1,6 +1,19 @@
 "use client";
 
 import {
+	ArrowLeft,
+	Calendar,
+	Edit3,
+	Loader2,
+	Sparkles,
+	Trash2,
+} from "lucide-react";
+import Link from "next/link";
+import { notFound, useParams, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { Header } from "@/components/header";
+import { SolutionDisplay } from "@/components/solution-display";
+import {
 	AlertDialog,
 	AlertDialogAction,
 	AlertDialogCancel,
@@ -11,18 +24,12 @@ import {
 	AlertDialogTitle,
 	AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { ArrowLeft, Calendar, Edit3, Loader2, Sparkles, Trash2 } from "lucide-react";
-import Link from "next/link";
-import { notFound, useParams, useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
-import { Header } from "@/components/header";
-import { SolutionDisplay } from "@/components/solution-display";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Textarea } from "@/components/ui/textarea";
-import { type Problem, problemsApi } from "@/lib/api";
 import { useToast } from "@/hooks/use-toast";
+import { type Problem, problemsApi } from "@/lib/api";
 
 export default function ProblemDetailPage() {
 	const { toast } = useToast();
@@ -199,7 +206,9 @@ export default function ProblemDetailPage() {
 										</AlertDialogTrigger>
 										<AlertDialogContent>
 											<AlertDialogHeader>
-												<AlertDialogTitle>問題を削除しますか？</AlertDialogTitle>
+												<AlertDialogTitle>
+													問題を削除しますか？
+												</AlertDialogTitle>
 												<AlertDialogDescription>
 													「{problem.title}」を削除してもよろしいですか？
 													この操作は元に戻せません。

--- a/frontend/app/tags/page.tsx
+++ b/frontend/app/tags/page.tsx
@@ -14,8 +14,8 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { problemsApi, tagsApi } from "@/lib/api";
 import { useToast } from "@/hooks/use-toast";
+import { problemsApi, tagsApi } from "@/lib/api";
 
 interface TagWithCount {
 	id: number;
@@ -145,9 +145,7 @@ export default function TagsPage() {
 									tag={tag}
 									count={count}
 									onDelete={(t) => setConfirmTag(t)}
-									onUpdate={handleUpdateTag}
 									isDeleting={deletingTag === tag}
-									isUpdating={updatingTag === tag}
 								/>
 							))}
 							<AlertDialog

--- a/frontend/app/tags/page.tsx
+++ b/frontend/app/tags/page.tsx
@@ -4,7 +4,18 @@ import { Tags } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Header } from "@/components/header";
 import { TagCard } from "@/components/tag-card";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { problemsApi, tagsApi } from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
 
 interface TagWithCount {
 	id: number;
@@ -13,10 +24,12 @@ interface TagWithCount {
 }
 
 export default function TagsPage() {
+	const { toast } = useToast();
 	const [tagStats, setTagStats] = useState<TagWithCount[]>([]);
 	const [isLoading, setIsLoading] = useState(true);
 	const [deletingTag, setDeletingTag] = useState<string | null>(null);
 	const [updatingTag, setUpdatingTag] = useState<string | null>(null);
+	const [confirmTag, setConfirmTag] = useState<string | null>(null);
 
 	useEffect(() => {
 		const fetchTagStats = async () => {
@@ -75,16 +88,21 @@ export default function TagsPage() {
 	};
 
 	const handleDeleteTag = async (tag: string) => {
-		if (!confirm(`"${tag}" を削除してもよろしいですか？`)) return;
 		setDeletingTag(tag);
 		try {
 			const entry = tagStats.find((t) => t.tag === tag);
 			if (entry) {
 				await tagsApi.deleteTag(entry.id);
 				setTagStats((prev) => prev.filter((t) => t.tag !== tag));
+				toast({ title: "タグを削除しました" });
 			}
 		} catch (error) {
 			console.error("Failed to delete tag:", error);
+			toast({
+				title: "エラー",
+				description: "タグの削除に失敗しました。",
+				variant: "destructive",
+			});
 		} finally {
 			setDeletingTag(null);
 		}
@@ -126,12 +144,39 @@ export default function TagsPage() {
 									key={tag}
 									tag={tag}
 									count={count}
-									onDelete={handleDeleteTag}
+									onDelete={(t) => setConfirmTag(t)}
 									onUpdate={handleUpdateTag}
 									isDeleting={deletingTag === tag}
 									isUpdating={updatingTag === tag}
 								/>
 							))}
+							<AlertDialog
+								open={!!confirmTag}
+								onOpenChange={(open) => {
+									if (!open) setConfirmTag(null);
+								}}
+							>
+								<AlertDialogContent>
+									<AlertDialogHeader>
+										<AlertDialogTitle>タグを削除しますか？</AlertDialogTitle>
+										<AlertDialogDescription>
+											「{confirmTag}」を削除してもよろしいですか？
+											この操作は元に戻せません。
+										</AlertDialogDescription>
+									</AlertDialogHeader>
+									<AlertDialogFooter>
+										<AlertDialogCancel>キャンセル</AlertDialogCancel>
+										<AlertDialogAction
+											onClick={() => {
+												if (confirmTag) handleDeleteTag(confirmTag);
+												setConfirmTag(null);
+											}}
+										>
+											削除
+										</AlertDialogAction>
+									</AlertDialogFooter>
+								</AlertDialogContent>
+							</AlertDialog>
 						</div>
 					)}
 				</div>


### PR DESCRIPTION
## Summary
- tags/page.tsx: タグ削除成功/失敗のトースト追加、confirm()→AlertDialogに変更
- problems/[id]/page.tsx: 削除ボタン+AlertDialog追加、AI生成/保存のトースト追加