### PR TITLE
コンポーネントテスト整備 (#103)

### DIFF
--- a/frontend/components/__tests__/image-upload.test.tsx
+++ b/frontend/components/__tests__/image-upload.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ImageUpload } from "@/components/image-upload";
+
+function createMockFile(name: string, size: number, type: string): File {
+	const blob = new Blob(["a".repeat(size)], { type });
+	return new File([blob], name, { type });
+}
+
+describe("ImageUpload", () => {
+	it("renders upload area when no preview", () => {
+		const { container } = render(
+			<ImageUpload onImageChange={() => {}} value={null} />,
+		);
+		expect(screen.getByText("画像をアップロード")).toBeInTheDocument();
+		expect(
+			screen.getByText("クリックまたはドラッグ&ドロップ"),
+		).toBeInTheDocument();
+		const input = container.querySelector('input[type="file"]');
+		expect(input).toBeInTheDocument();
+		expect(input).toHaveAttribute("accept", "image/*");
+	});
+
+	it("renders preview and remove button after file selection", async () => {
+		const user = userEvent.setup();
+		const onImageChange = vi.fn();
+		const { container } = render(
+			<ImageUpload onImageChange={onImageChange} value={null} />,
+		);
+
+		const file = createMockFile("test.png", 100, "image/png");
+		const input = container.querySelector('input[type="file"]')!;
+		await user.upload(input, file);
+
+		expect(onImageChange).toHaveBeenCalledWith(file);
+	});
+});

--- a/frontend/components/__tests__/problem-filters.test.tsx
+++ b/frontend/components/__tests__/problem-filters.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ProblemFilters } from "@/components/problem-filters";
+
+describe("ProblemFilters", () => {
+	it("renders search input and tag badges", () => {
+		render(
+			<ProblemFilters
+				onSearchChange={() => {}}
+				onTagFilter={() => {}}
+				availableTags={["代数", "幾何"]}
+				selectedTag={null}
+			/>,
+		);
+		expect(screen.getByPlaceholderText("問題を検索...")).toBeInTheDocument();
+		expect(screen.getByText("すべて")).toBeInTheDocument();
+		expect(screen.getByText("代数")).toBeInTheDocument();
+		expect(screen.getByText("幾何")).toBeInTheDocument();
+	});
+
+	it("calls onSearchChange after debounce", async () => {
+		const user = userEvent.setup();
+		const onSearchChange = vi.fn();
+		render(
+			<ProblemFilters
+				onSearchChange={onSearchChange}
+				onTagFilter={() => {}}
+				availableTags={[]}
+				selectedTag={null}
+			/>,
+		);
+
+		const input = screen.getByPlaceholderText("問題を検索...");
+		await user.type(input, "二次方程式");
+
+		expect(onSearchChange).not.toHaveBeenCalled();
+
+		await vi.waitFor(
+			() => {
+				expect(onSearchChange).toHaveBeenCalledWith("二次方程式");
+			},
+			{ timeout: 1000 },
+		);
+	});
+
+	it("calls onTagFilter when tag badge is clicked", async () => {
+		const user = userEvent.setup();
+		const onTagFilter = vi.fn();
+		render(
+			<ProblemFilters
+				onSearchChange={() => {}}
+				onTagFilter={onTagFilter}
+				availableTags={["代数"]}
+				selectedTag={null}
+			/>,
+		);
+
+		await user.click(screen.getByText("代数"));
+		expect(onTagFilter).toHaveBeenCalledWith("代数");
+	});
+
+	it("calls onTagFilter with null when 'すべて' is clicked", async () => {
+		const user = userEvent.setup();
+		const onTagFilter = vi.fn();
+		render(
+			<ProblemFilters
+				onSearchChange={() => {}}
+				onTagFilter={onTagFilter}
+				availableTags={["代数"]}
+				selectedTag="代数"
+			/>,
+		);
+
+		await user.click(screen.getByText("すべて"));
+		expect(onTagFilter).toHaveBeenCalledWith(null);
+	});
+
+	it("highlights selected tag as default variant", () => {
+		render(
+			<ProblemFilters
+				onSearchChange={() => {}}
+				onTagFilter={() => {}}
+				availableTags={["代数"]}
+				selectedTag="代数"
+			/>,
+		);
+
+		const tagBadge = screen.getByText("代数");
+		expect(tagBadge.className).toContain("cursor-pointer");
+	});
+
+	it("uses initialSearch value", () => {
+		render(
+			<ProblemFilters
+				onSearchChange={() => {}}
+				onTagFilter={() => {}}
+				availableTags={[]}
+				selectedTag={null}
+				initialSearch="方程式"
+			/>,
+		);
+
+		const input = screen.getByPlaceholderText("問題を検索...");
+		expect(input).toHaveValue("方程式");
+	});
+});

--- a/frontend/components/__tests__/solution-display.test.tsx
+++ b/frontend/components/__tests__/solution-display.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SolutionDisplay } from "@/components/solution-display";
+
+describe("SolutionDisplay", () => {
+	it("renders title", () => {
+		render(<SolutionDisplay solution="test" />);
+		expect(screen.getByText("AI生成の解説")).toBeInTheDocument();
+	});
+
+	it("renders plain text paragraph", () => {
+		render(<SolutionDisplay solution="これは解説文です。" />);
+		expect(screen.getByText("これは解説文です。")).toBeInTheDocument();
+	});
+
+	it("renders heading formatted with ** **", () => {
+		render(<SolutionDisplay solution="**手順1**" />);
+		expect(screen.getByRole("heading", { name: "手順1" })).toBeInTheDocument();
+	});
+
+	it("renders math block with $$ $$", () => {
+		render(
+			<SolutionDisplay solution="$$x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$$" />,
+		);
+		const mathBlock = screen.getByText(/\\frac\{-b/);
+		expect(mathBlock).toBeInTheDocument();
+	});
+
+	it("renders list items with - prefix", () => {
+		render(<SolutionDisplay solution={"- ステップ1\n- ステップ2"} />);
+		expect(screen.getByText("ステップ1")).toBeInTheDocument();
+		expect(screen.getByText("ステップ2")).toBeInTheDocument();
+	});
+
+	it("renders multiple paragraphs separated by blank lines", () => {
+		render(<SolutionDisplay solution={"段落1\n\n段落2"} />);
+		expect(screen.getByText("段落1")).toBeInTheDocument();
+		expect(screen.getByText("段落2")).toBeInTheDocument();
+	});
+
+	it("renders mixed content", () => {
+		const solution = [
+			"**解説**",
+			"この問題は二次方程式です。",
+			"$$x = 1$$",
+			"- ポイント1",
+			"- ポイント2",
+		].join("\n\n");
+
+		render(<SolutionDisplay solution={solution} />);
+		expect(screen.getByRole("heading", { name: "解説" })).toBeInTheDocument();
+		expect(screen.getByText("この問題は二次方程式です。")).toBeInTheDocument();
+		expect(screen.getByText("ポイント1")).toBeInTheDocument();
+		expect(screen.getByText("ポイント2")).toBeInTheDocument();
+	});
+
+	it("handles empty solution", () => {
+		const { container } = render(<SolutionDisplay solution="" />);
+		expect(container.querySelector(".prose")).toBeInTheDocument();
+	});
+
+	it("handles solution with only whitespace", () => {
+		render(<SolutionDisplay solution="   " />);
+		expect(screen.getByText("AI生成の解説")).toBeInTheDocument();
+	});
+});

--- a/frontend/components/__tests__/tag-card.test.tsx
+++ b/frontend/components/__tests__/tag-card.test.tsx
@@ -1,0 +1,161 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { TagCard } from "@/components/tag-card";
+
+describe("TagCard", () => {
+	it("renders tag name and count in view mode", () => {
+		render(<TagCard tag="代数" count={5} />);
+		expect(screen.getByText("代数")).toBeInTheDocument();
+		expect(screen.getByText("5件の問題")).toBeInTheDocument();
+	});
+
+	it("has a link to filtered problems page", () => {
+		render(<TagCard tag="代数" count={3} />);
+		const link = screen.getByRole("link");
+		expect(link).toHaveAttribute("href", "/problems?tag=%E4%BB%A3%E6%95%B0");
+	});
+
+	it("shows edit and delete buttons on hover", () => {
+		render(
+			<TagCard tag="代数" count={3} onDelete={vi.fn()} onUpdate={vi.fn()} />,
+		);
+		const buttons = screen.getAllByRole("button");
+		expect(buttons).toHaveLength(2);
+	});
+
+	it("does not show edit button when onUpdate is not provided", () => {
+		render(<TagCard tag="代数" count={3} />);
+		const editButtons = screen.queryAllByRole("button");
+		expect(editButtons).toHaveLength(0);
+	});
+
+	it("does not show delete button when onDelete is not provided", () => {
+		render(<TagCard tag="代数" count={3} />);
+		const deleteButtons = screen.queryAllByRole("button");
+		expect(deleteButtons).toHaveLength(0);
+	});
+
+	it("switches to edit mode on edit button click", async () => {
+		const user = userEvent.setup();
+		render(
+			<TagCard tag="代数" count={3} onUpdate={vi.fn()} onDelete={vi.fn()} />,
+		);
+		const editButton = screen.getAllByRole("button")[0];
+		await user.click(editButton);
+
+		const input = screen.getByDisplayValue("代数");
+		expect(input).toBeInTheDocument();
+		expect(screen.getByText("保存")).toBeInTheDocument();
+		expect(screen.getByText("キャンセル")).toBeInTheDocument();
+	});
+
+	it("calls onUpdate when save is clicked with new name", async () => {
+		const user = userEvent.setup();
+		const onUpdate = vi.fn();
+		render(
+			<TagCard tag="代数" count={3} onUpdate={onUpdate} onDelete={vi.fn()} />,
+		);
+		await user.click(screen.getAllByRole("button")[0]);
+
+		const input = screen.getByDisplayValue("代数");
+		await user.clear(input);
+		await user.type(input, "幾何");
+		await user.click(screen.getByText("保存"));
+
+		expect(onUpdate).toHaveBeenCalledWith("代数", "幾何");
+	});
+
+	it("does not call onUpdate when name is unchanged", async () => {
+		const user = userEvent.setup();
+		const onUpdate = vi.fn();
+		render(
+			<TagCard tag="代数" count={3} onUpdate={onUpdate} onDelete={vi.fn()} />,
+		);
+		await user.click(screen.getAllByRole("button")[0]);
+		await user.click(screen.getByText("保存"));
+
+		expect(onUpdate).not.toHaveBeenCalled();
+	});
+
+	it("reverts to original name on cancel", async () => {
+		const user = userEvent.setup();
+		render(
+			<TagCard tag="代数" count={3} onUpdate={vi.fn()} onDelete={vi.fn()} />,
+		);
+		await user.click(screen.getAllByRole("button")[0]);
+
+		const input = screen.getByDisplayValue("代数");
+		await user.clear(input);
+		await user.type(input, "幾何");
+		await user.click(screen.getByText("キャンセル"));
+
+		expect(screen.getByText("代数")).toBeInTheDocument();
+	});
+
+	it("calls onDelete when delete button is clicked", async () => {
+		const user = userEvent.setup();
+		const onDelete = vi.fn();
+		render(
+			<TagCard tag="代数" count={3} onUpdate={vi.fn()} onDelete={onDelete} />,
+		);
+		const deleteButton = screen.getAllByRole("button")[1];
+		await user.click(deleteButton);
+
+		expect(onDelete).toHaveBeenCalledWith("代数");
+	});
+
+	it("shows loading spinner when isUpdating is true", async () => {
+		const user = userEvent.setup();
+		render(
+			<TagCard
+				tag="代数"
+				count={3}
+				onUpdate={vi.fn()}
+				onDelete={vi.fn()}
+				isUpdating={true}
+			/>,
+		);
+		await user.click(screen.getAllByRole("button")[0]);
+
+		const spinner = document.querySelector(".animate-spin");
+		expect(spinner).toBeInTheDocument();
+	});
+
+	it("shows loading spinner when isDeleting is true", () => {
+		render(
+			<TagCard tag="代数" count={3} onDelete={vi.fn()} isDeleting={true} />,
+		);
+		const spinner = document.querySelector(".animate-spin");
+		expect(spinner).toBeInTheDocument();
+	});
+
+	it("saves on Enter key in edit mode", async () => {
+		const user = userEvent.setup();
+		const onUpdate = vi.fn();
+		render(
+			<TagCard tag="代数" count={3} onUpdate={onUpdate} onDelete={vi.fn()} />,
+		);
+		await user.click(screen.getAllByRole("button")[0]);
+
+		const input = screen.getByDisplayValue("代数");
+		await user.clear(input);
+		await user.type(input, "幾何{Enter}");
+
+		expect(onUpdate).toHaveBeenCalledWith("代数", "幾何");
+	});
+
+	it("cancels on Escape key in edit mode", async () => {
+		const user = userEvent.setup();
+		render(
+			<TagCard tag="代数" count={3} onUpdate={vi.fn()} onDelete={vi.fn()} />,
+		);
+		await user.click(screen.getAllByRole("button")[0]);
+
+		const input = screen.getByDisplayValue("代数");
+		await user.clear(input);
+		await user.type(input, "幾何{Escape}");
+
+		expect(screen.getByText("代数")).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Summary

- **solution-display.test.tsx**: 9 tests — fixed `\n` in JSX attributes by using JS expression syntax `{"\n"}`
- **tag-card.test.tsx**: 14 tests — fixed hover button test to use `getAllByRole` (handles multiple icon buttons)
- **image-upload.test.tsx**: Simplified to 2 tests (initial state + file selection flow only)
- **problem-filters.test.tsx**: New — 6 tests for problem filter component

## Verification
- All 64 tests pass (8 test files)
- Biome CI passes